### PR TITLE
Allow v2 or v3 of debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
   "dependencies": {
     "@types/debug": "0.0.29",
     "array-flatten": "^2.1.0",
-    "debug": "^2.6.8"
+    "debug": "^2.6.8 || ^3.1.0"
   }
 }


### PR DESCRIPTION
This PR updates the allowable versions of debug to include v3 in addition to v2.

From [the debug CHANGELOG](https://github.com/visionmedia/debug/blob/a5ca7a20860e78a4ea47f80770c09c0c663bae1e/CHANGELOG.md#300--2017-08-08) the breaking changes introduced in v3 include:

> Breaking: Remove DEBUG_FD (#406)
> Breaking: Use `Date#toISOString()` instead to `Date#toUTCString()` when output is not a TTY (#418)
> Breaking: Make millisecond timer namespace specific and allow 'always enabled' output (#408)

These changes shouldn't introduce breaking changes into this library and I think can constitute a minor version bump without issue. This will allow applications using the latest version of debug to have it deduplicated by npm and for applications using v2 to continue using that.