### PR TITLE
Generic compose

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,11 +65,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "array-flatten": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
-      "integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ=="
-    },
     "assertion-error": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   },
   "dependencies": {
     "@types/debug": "0.0.31",
-    "array-flatten": "^2.1.2",
     "debug": "^4.1.0"
   }
 }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -2,15 +2,14 @@ import { compose, Next, Middleware } from './index'
 import { expect } from 'chai'
 
 describe('compose middleware', () => {
-  it('should be assignable to array of middleware', (done) => {
-    const pipeline = <T, U> (...middlewares: Array<Middleware<T, U>>) => compose(middlewares)
-    const middleware = pipeline((req: undefined, res: undefined, next: () => void) => next())
+  it('should compose one middleware', (done) => {
+    const middleware = compose((req: undefined, res: undefined, next: () => void) => next())
 
     return middleware(undefined, undefined, done)
   })
 
-  it('should compose middleware', (done) => {
-    const middleware = compose([
+  it('should compose multiple middleware', (done) => {
+    const middleware = compose(
       function (req: any, res: any, next: Next) {
         req.one = true
         next()
@@ -19,7 +18,7 @@ describe('compose middleware', () => {
         req.two = true
         next()
       }
-    ])
+    )
 
     const req: any = {}
     const res: any = {}
@@ -34,7 +33,7 @@ describe('compose middleware', () => {
   })
 
   it('should exit with an error', (done) => {
-    const middleware = compose([
+    const middleware = compose(
       function (req: any, res: any, next: Next) {
         req.one = true
         next(new Error('test'))
@@ -43,7 +42,7 @@ describe('compose middleware', () => {
         req.two = true
         next()
       }
-    ])
+    )
 
     const req: any = {}
     const res: any = {}
@@ -58,12 +57,12 @@ describe('compose middleware', () => {
   })
 
   it('should short-cut handler with a single function', (done) => {
-    const middleware = compose([
+    const middleware = compose(
       function (req: any, res: any, next: Next) {
         req.one = true
         next()
       }
-    ])
+    )
 
     const req: any = {}
     const res: any = {}
@@ -93,13 +92,13 @@ describe('compose middleware', () => {
   })
 
   it('should noop with no middleware', (done) => {
-    const middleware = compose([])
+    const middleware = compose()
 
     middleware({}, {}, done)
   })
 
   it('should validate all handlers are functions', () => {
-    expect(() => compose(['foo'] as any)).to.throw(TypeError, 'Handlers must be a function')
+    expect(() => compose('foo' as any)).to.throw(TypeError, 'Handlers must be a function')
   })
 
   it('should support error handlers', (done) => {

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,96 +1,9 @@
-import { compose, Next, Middleware } from './index'
+// tslint:disable handle-callback-err
+
+import { compose, Next, RequestHandler, ErrorHandler } from './index'
 import { expect } from 'chai'
 
 describe('compose middleware', () => {
-  it('should compose one middleware', (done) => {
-    const middleware = compose((req: undefined, res: undefined, next: () => void) => next())
-
-    return middleware(undefined, undefined, done)
-  })
-
-  it('should compose multiple middleware', (done) => {
-    const middleware = compose(
-      function (req: any, res: any, next: Next) {
-        req.one = true
-        next()
-      },
-      function (req: any, res: any, next: Next) {
-        req.two = true
-        next()
-      }
-    )
-
-    const req: any = {}
-    const res: any = {}
-
-    middleware(req, res, function (err) {
-      expect(err).to.equal(undefined)
-      expect(req.one).to.equal(true)
-      expect(req.two).to.equal(true)
-
-      return done()
-    })
-  })
-
-  it('should exit with an error', (done) => {
-    const middleware = compose(
-      function (req: any, res: any, next: Next) {
-        req.one = true
-        next(new Error('test'))
-      },
-      function (req: any, res: any, next: Next) {
-        req.two = true
-        next()
-      }
-    )
-
-    const req: any = {}
-    const res: any = {}
-
-    middleware(req, res, function (err) {
-      expect(err).instanceOf(Error)
-      expect(req.one).to.equal(true)
-      expect(req.two).to.equal(undefined)
-
-      return done()
-    })
-  })
-
-  it('should short-cut handler with a single function', (done) => {
-    const middleware = compose(
-      function (req: any, res: any, next: Next) {
-        req.one = true
-        next()
-      }
-    )
-
-    const req: any = {}
-    const res: any = {}
-
-    middleware(req, res, function (err) {
-      expect(err).to.equal(undefined)
-      expect(req.one).to.equal(true)
-
-      return done()
-    })
-  })
-
-  it('should accept a single function', (done) => {
-    const middleware = compose<any, any>(function (req: any, res: any, next: Next) {
-      req.one = true
-      next()
-    })
-
-    const req: any = {}
-
-    middleware(req, {}, function (err?: Error | null) {
-      expect(err).to.equal(undefined)
-      expect(req.one).to.equal(true)
-
-      return done()
-    })
-  })
-
   it('should noop with no middleware', (done) => {
     const middleware = compose()
 
@@ -99,34 +12,6 @@ describe('compose middleware', () => {
 
   it('should validate all handlers are functions', () => {
     expect(() => compose('foo' as any)).to.throw(TypeError, 'Handlers must be a function')
-  })
-
-  it('should support error handlers', (done) => {
-    const middleware = compose(
-      function (req: any, res: any, next: Next) {
-        return next(new Error('test'))
-      },
-      function (_: Error, req: any, res: any, next: Next) {
-        return next()
-      },
-      function (req: any, res: any, next: Next) {
-        req.success = true
-        return next()
-      },
-      function (_: Error, req: any, res: any, next: Next) {
-        req.fail = true
-        return next()
-      }
-    )
-
-    const req: any = {}
-
-    middleware(req, {} as any, function (err) {
-      expect(req.fail).to.equal(undefined)
-      expect(req.success).to.equal(true)
-
-      return done(err)
-    })
   })
 
   it('should error when calling `next()` multiple times', (done) => {
@@ -146,22 +31,331 @@ describe('compose middleware', () => {
     }
   })
 
-  it('should forward thrown errors', (done) => {
-    const middleware = compose<any, any>(
-      function (req: any, res: any, next: Next) {
-        throw new Error('Boom!')
-      }
-    )
+  describe('composing one middleware', () => {
+    context('given a success handler', () => {
+      context('that calls next without error', () => {
+        it('behaves like middleware passed', (done) => {
+          const middleware = compose(
+            function (req: any, res: any, next: Next) {
+              req.one = true
+              next()
+            }
+          )
 
-    middleware({}, {}, function (err) {
-      expect(err).instanceOf(Error)
-      expect(err!.message).to.equal('Boom!')
+          const req: any = {}
+          const res: any = {}
 
-      return done()
+          middleware(req, res, function (err) {
+            expect(err).to.equal(undefined)
+            expect(req.one).to.equal(true)
+
+            return done()
+          })
+        })
+      })
+
+      context('that calls next with error', () => {
+        it('behaves like middleware passed', (done) => {
+          const error = new Error('Boom!')
+          const middleware = compose(
+            function (req: any, res: any, next: Next) {
+              req.one = true
+              next(error)
+            }
+          )
+
+          const req: any = {}
+          const res: any = {}
+
+          middleware(req, res, function (err) {
+            expect(err).to.equal(error)
+            expect(req.one).to.equal(true)
+
+            return done()
+          })
+        })
+      })
+
+      context('that throws an error', () => {
+        it('next callback collects the error thrown', (done) => {
+          const error = new Error('Boom!')
+          const middleware = compose(
+            function (req: any, res: any, next: Next) {
+              req.one = true
+              throw error
+              req.two = true
+            }
+          )
+
+          const req: any = {}
+          const res: any = {}
+
+          middleware(req, res, function (err) {
+            expect(err).to.equal(error)
+            expect(req.one).to.equal(true)
+            expect(req.two).to.equal(undefined)
+
+            return done()
+          })
+        })
+      })
+
+      context('and does not call next', () => {
+        it('middleware is called but next is not called', () => {
+          const middleware = compose(
+            function (req: any, res: any, next: Next) {
+              req.one = true
+            }
+          )
+
+          const req: any = {}
+          const res: any = {}
+
+          middleware(req, res, function (err) {
+            expect.fail('next should not be called')
+          })
+          expect(req.one).to.equal(true)
+        })
+      })
+    })
+
+    context('given an error handler', () => {
+      context('which is called with a null argument', () => {
+        it('omits the middleware call but calls next', (done) => {
+          const middleware = compose(
+            function (err: Error | null, req: any, res: any, next: Next) {
+              req.one = true
+              next()
+            }
+          )
+
+          const req: any = {}
+          const res: any = {}
+
+          middleware(null, req, res, function (err) {
+            expect(err).to.equal(null)
+            expect(req.one).to.equal(undefined)
+
+            return done()
+          })
+        })
+      })
+
+      context('which is called with an error argument', () => {
+        context('and calls next without error', () => {
+          it('behaves like middleware passed', (done) => {
+            const middleware = compose(
+              function (err: Error | null, req: any, res: any, next: Next) {
+                req.one = true
+                next()
+              }
+            )
+
+            const req: any = {}
+            const res: any = {}
+            const err: Error = new Error('Boom!')
+
+            middleware(err, req, res, function (err) {
+              expect(err).to.equal(undefined)
+              expect(req.one).to.equal(true)
+
+              return done()
+            })
+          })
+        })
+
+        context('and calls next with error', () => {
+          it('middleware is called and next collect the error', (done) => {
+            const error: Error = new Error('Boom!')
+            const middleware = compose(
+              function (err: Error | null, req: any, res: any, next: Next) {
+                req.one = true
+                next(error)
+              }
+            )
+
+            const req: any = {}
+            const res: any = {}
+            const err: Error = new Error('Bang!')
+
+            middleware(err, req, res, function (err) {
+              expect(err).to.equal(error)
+              expect(req.one).to.equal(true)
+
+              return done()
+            })
+          })
+        })
+
+        context('and throws an error', () => {
+          it('next callback collects the error thrown', (done) => {
+            const error = new Error('Boom!')
+            const middleware = compose(
+              function (err: Error | null, req: any, res: any, next: Next) {
+                req.one = true
+                throw error
+                req.two = true
+              }
+            )
+
+            const req: any = {}
+            const res: any = {}
+            const err: Error = new Error('Pim!')
+
+            middleware(err, req, res, function (err) {
+              expect(err).to.equal(error)
+              expect(req.one).to.equal(true)
+              expect(req.two).to.equal(undefined)
+
+              return done()
+            })
+          })
+        })
+
+        context('and does not call next', () => {
+          it('middleware is called but next is not called', () => {
+            const error = new Error('Boom!')
+            const middleware = compose(
+              function (err: Error | null, req: any, res: any, next: Next) {
+                req.one = true
+              }
+            )
+
+            const req: any = {}
+            const res: any = {}
+            const err: Error = new Error('Bang!')
+
+            middleware(err, req, res, function (err) {
+              expect.fail('next should not be called')
+            })
+            expect(req.one).to.be.equal(true)
+          })
+        })
+      })
     })
   })
 
-  it('should not cascade errors from `done()`', (done) => {
+  describe('compose multiple middlewares', () => {
+    context('composing success request handlers', () => {
+      it('should call both middlewares', (done) => {
+        const middleware = compose(
+          function (req: any, res: any, next: Next) {
+            req.one = true
+            next()
+          },
+          function (req: any, res: any, next: Next) {
+            req.two = true
+            next()
+          }
+        )
+
+        const req: any = {}
+        const res: any = {}
+
+        middleware(req, res, function (err) {
+          expect(err).to.equal(undefined)
+          expect(req.one).to.equal(true)
+          expect(req.two).to.equal(true)
+
+          return done()
+        })
+      })
+    })
+
+    context('first request handler propagate an error', () => {
+      it('does not call second request handler and propagates the error', (done) => {
+        const middleware = compose(
+          function (req: any, res: any, next: Next) {
+            req.one = true
+            next(new Error('test'))
+          },
+          function (req: any, res: any, next: Next) {
+            req.two = true
+            next()
+          }
+        )
+
+        const req: any = {}
+        const res: any = {}
+
+        middleware(req, res, function (err) {
+          expect(err).instanceOf(Error)
+          expect(req.one).to.equal(true)
+          expect(req.two).to.equal(undefined)
+
+          return done()
+        })
+      })
+    })
+
+    context('starting with a request handler', () => {
+      it('should support error handlers', (done) => {
+        const middleware = compose(
+          function (req: any, res: any, next: Next) {
+            return next(new Error('test'))
+          },
+          function (_: Error | null, req: any, res: any, next: Next) {
+            return next()
+          },
+          function (req: any, res: any, next: Next) {
+            req.success = true
+            return next()
+          },
+          function (_: Error | null, req: any, res: any, next: Next) {
+            req.fail = true
+            return next()
+          }
+        )
+
+        const req: any = {}
+
+        middleware(req, {} as any, function (err) {
+          expect(req.fail).to.equal(undefined)
+          expect(req.success).to.equal(true)
+
+          return done(err)
+        })
+      })
+    })
+
+    context('starting with a error handler', () => {
+      it('creates an error handler', (done) => {
+        const middleware = compose(
+          function (err: Error | null, req: any, res: any, next: Next) {
+            res.one = true
+            return next(err)
+          },
+          function (req: any, res: any, next: Next) {
+            res.two = true
+            return next(new Error('test'))
+          },
+          function (err: Error | null, req: any, res: any, next: Next) {
+            res.fail = err
+            return next()
+          },
+          function (req: any, res: any, next: Next) {
+            res.success = true
+            return next()
+          }
+        )
+
+        const res: any = {}
+        const error: Error = new Error('Boom!')
+
+        middleware(error, {} as any, res, function (err) {
+          expect(res.one).to.equal(true)
+          expect(res.two).to.equal(undefined)
+          expect(res.fail).to.equal(error)
+          expect(res.success).to.equal(true)
+          expect(err).to.equal(undefined)
+
+          return done()
+        })
+      })
+    })
+  })
+
+  it('next callback should not cascade errors from `done()`', (done) => {
     const request = {
       done: 0,
       first: 0,


### PR DESCRIPTION
Hi @blakeembrey 

During the implementation, I noticed that Express app.use and app[METHOD] accepts variadic number of middlewares implementing internally the composition as @knksmith57 expected in #4  

However having this implementation is useful for having same behaviour as express in other server libraries like connect.

Cheers!