### PR TITLE
Change Next err paramter to type any

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { flatten } from "array-flatten";
 
 const log = debug("compose-middleware");
 
-export type Next<T = void> = (err?: Error | null) => T;
+export type Next<T = void> = (err?: any) => T;
 export type RequestHandler<T, U, V = void> = (
   req: T,
   res: U,


### PR DESCRIPTION
Fixes: #24 

I found that the type conflict comes from the err parameter type.

@types/express: `(err?: any): void`
compose-middleware: `(err?: Error | null): void`

This PR changes the Next err parameter type to `any` which matches @types/express.

Reproduction: https://github.com/thomasraydeniscool/compose-middleware-repro